### PR TITLE
Fix spark version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <data.pipeline.parent>system:cdap-data-pipeline[6.1.2,7.0.0-SNAPSHOT)</data.pipeline.parent>
     <data.stream.parent>system:cdap-data-streams[6.1.2,7.0.0-SNAPSHOT)</data.stream.parent>
     <cdap.version>6.1.2</cdap.version>
-    <spark.version>2.3.4</spark.version>
+    <spark.version>2.1.3</spark.version>
     <hydrator.version>2.3.4</hydrator.version>
     <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
   </properties>


### PR DESCRIPTION
io.cdap.cdap:cdap-unit-test-spark2_2.11 pulls in spark 2.1.3, so use the same version of spark-core_2.11 and spark-sql_2.11
to avoid versino mismatches.

Without this change, unit tests fail with this error:
```
java.lang.AbstractMethodError: null
	at org.apache.spark.internal.Logging$class.initializeLogIfNecessary(Logging.scala:99) ~[spark-core_2.11-2.3.4.jar:2.3.4]
	at org.apache.spark.repl.ExecutorClassLoader.initializeLogIfNecessary(ExecutorClassLoader.scala:42) ~[na:2.1.3]
	at org.apache.spark.internal.Logging$class.log(Logging.scala:46) ~[spark-core_2.11-2.3.4.jar:2.3.4]
	at org.apache.spark.repl.ExecutorClassLoader.log(ExecutorClassLoader.scala:42) ~[na:2.1.3]

```